### PR TITLE
Check if the string in cc-search-directories is accessable.

### DIFF
--- a/ac-c-headers.el
+++ b/ac-c-headers.el
@@ -18,6 +18,7 @@
 
 ;; Author: zk_phi
 ;; URL: http://hins11.yu-yake.com/
+;; Package-Version: 20141231.814
 ;; Version: 1.0.0
 ;; Package-Requires: ((auto-complete "1.3.1"))
 
@@ -69,7 +70,9 @@
                                                 file)
                                                (t
                                                 nil)))
-                                       (directory-files (concat prefix dir) nil))))
+				       (if (file-accessible-directory-p dir) 
+					   (directory-files (concat prefix dir) nil)
+					 nil))))
                               cc-search-directories)))
                 ac-c-headers--files-cache))))
 


### PR DESCRIPTION
In Ubuntu, the default value of cc-search-directories the value
"/usr/local/include/*", but this is not a valid file/dir name,
and because of the you need to modify cc-search-directories
for ac-c-header sources to work.  With this modification, it
should work out of the box.
