### PR TITLE
Fix "no such directory" error

### DIFF
--- a/ac-c-headers.el
+++ b/ac-c-headers.el
@@ -60,20 +60,21 @@
                       (apply 'append
                              (mapcar
                               (lambda (dir)
-                                (when (file-accessible-directory-p dir)
-                                  (delq nil
-                                        (mapcar
-                                         (lambda (file)
-                                           (cond ((file-directory-p (concat prefix file))
-                                                  (concat file "/"))
-                                                 ((string-match "\\h$" file)
-                                                  file)
-                                                 (t
-                                                  nil)))
-                                         (directory-files (concat prefix dir) nil)))))
-                              cc-search-directories)))
-                ac-c-headers--files-cache))))
-
+				(let ((path (concat (file-name-as-directory dir) prefix)))
+				  (when (file-accessible-directory-p path)
+				    (delq nil
+					  (mapcar
+					   (lambda (file)
+					     (cond ((file-directory-p (concat path file))
+						    (concat file "/"))
+						   ((string-match "\\h$" file)
+						    file)
+						   (t
+						    nil)))
+					   (directory-files path nil))))))
+			      cc-search-directories)))
+		ac-c-headers--files-cache))))
+  
 (defun ac-c-headers--files-list (&optional point)
   "returns possible completions at the point"
   (save-excursion


### PR DESCRIPTION
Fix 'no such directory' error when cc-search-directory is end without "/".
Fix it won't works when both prefix and dir are not empty string.
